### PR TITLE
Increased button font size

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -29,11 +29,13 @@ body {
   background: transparent;
   border: 0.1rem solid var(--mainGreen);
   color: var(--mainGreen);
+  font-size: 1.2rem;
 }
 .expense-submit {
   background: transparent;
   border: 0.1rem solid var(--mainRed);
   color: var(--mainRed);
+  font-size: 1.2rem;
 }
 .expense-submit:hover {
   background: var(--mainRed);


### PR DESCRIPTION
In this commit, the font size of 'Calculate' button in both Budget and Expenses box have been updated. 
It is not set to 1.2rem (a little bigger than default).